### PR TITLE
FileName Zero-Padding bugfix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+# exclude bin and obj directories
+[Bb][Ii][Nn]
+[Oo][Bb][Jj]

--- a/Splitter/FileSplitter.cs
+++ b/Splitter/FileSplitter.cs
@@ -376,7 +376,8 @@ namespace FileSplitter {
 
                 // Builds default pattern if FileFormatPattern is null
                 if (FileFormatPattern == null) {
-                    String zeros = new String('0',  this.Parts); // Padding
+                    // Use the part's string length (e.g. '123' -> 3) to determine the amount of padding needed
+                    String zeros = new String('0', this.Parts.ToString().Length); // Padding
                     FileFormatPattern = Path.GetFileNameWithoutExtension(this.FileName) + "_{0:" + zeros + "}({1:" + zeros + "})" + fileNameInfo.Extension;
                 }
                 


### PR DESCRIPTION
Fixed the zero-padding; it added 23 zero's for me on a 23-part file.
I also added .gitignore entries for windows to prevent generated content
to be submitted (bin and obj dirs).