### PR TITLE
Refactored the code to use constants, enums and reflection for parameter and split definitions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+# exclude bin and obj directories
+[Bb][Ii][Nn]
+[Oo][Bb][Jj]

--- a/Attributes/UnitAttribute.cs
+++ b/Attributes/UnitAttribute.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using System.Reflection;
+namespace FileSplitter.Attributes
+{
+    /// <summary>
+    /// Class to help out with units
+    /// </summary>
+    /// <created>Nick</created>
+    public class UnitAttribute : System.Attribute
+    {
+        /// <summary>
+        /// The step size to factor computer sizes
+        /// B => KiB => MiB => GiB => TiB => PiB
+        /// </summary>
+        /// <created>Nick</created>
+        internal const int ComputerSizeFactorStep = 1024;
+        /// <summary>
+        /// The way to identify the unit from the command-line
+        /// </summary>
+        /// <created>Nick</created>
+        public string Identifier { get; private set; }
+        /// <summary>
+        /// The computer-size factor to use when translating units
+        /// </summary>
+        /// <created>Nick</created>
+        public byte Factor { get; private set; }
+        /// <summary>
+        /// Cached and calculated property that holds the value that the unit represents
+        /// </summary>
+        /// <created>Nick</created>
+        public double CalculatedFactor { get; private set; }
+        /// <summary>
+        /// Allows you to specify a textual key and factor to indentify a SplitUnit
+        /// </summary>
+        /// <param name="identifier">The textual identifier to match against later</param>
+        /// <param name="factor">The step to use to calculate the meaning</param>
+        /// <created>Nick</created>
+        public UnitAttribute(string identifier, byte factor)
+        {
+            Identifier = identifier;
+            Factor = factor;
+            CalculatedFactor = Math.Pow(ComputerSizeFactorStep, Factor);
+        }
+        /// <summary>
+        /// Finds an enum value with the specified identifier
+        /// </summary>
+        /// <typeparam name="T">The enum to find a value that holds the attribute</typeparam>
+        /// <param name="identifier">The identifier field of the attribute to retireve</param>
+        /// <returns>an enum value with the specified identifier</returns>
+        /// <created>Nick</created>
+        public static T Parse<T>(string identifier)
+        {
+            Type type = typeof(T);
+            UnitAttribute toTest;
+            // Enumerate all public static fields
+            foreach (var field in type.GetFields(BindingFlags.Public | BindingFlags.Static))
+            {
+                // Check each attribute
+                foreach (var attribute in field.GetCustomAttributes(false))
+                {
+                    // Get the type of the attribute
+                    Type attributeType = attribute.GetType();
+                    // And verify that 
+                    if (attributeType == typeof(UnitAttribute))
+                    {
+                        toTest = attribute as UnitAttribute;
+                        if (toTest.Identifier == identifier)
+                        {
+                            return (T)field.GetValue(null);
+                        }
+                    }
+                }
+            }
+            return default(T);
+        }
+        /// <summary>
+        /// Retrieves the attribute (if available) that was set on an enum field
+        /// </summary>
+        /// <typeparam name="T">The enum to check</typeparam>
+        /// <param name="value">The enum value to get the attribute off of</param>
+        /// <returns>the attribute (if available) that was set on an enum field</returns>
+        /// <created>Nick</created>
+        public static UnitAttribute GetFromField<T>(T value)
+        {
+            Type type = typeof(T);
+            string enumPropertyNameToTest = value.ToString();
+            // Enumerate all public static fields
+            foreach (var field in type.GetFields(BindingFlags.Public | BindingFlags.Static))
+            {
+                if (field.Name == enumPropertyNameToTest)
+                {
+                    // Check each attribute
+                    foreach (var attribute in field.GetCustomAttributes(false))
+                    {
+                        // Get the type of the attribute
+                        Type attributeType = attribute.GetType();
+                        // And verify that 
+                        if (attributeType == typeof(UnitAttribute))
+                        {
+                            return attribute as UnitAttribute;
+                        }
+                    }
+                }
+            }
+            return null;
+        }
+    }
+}

--- a/ComboboxItem.cs
+++ b/ComboboxItem.cs
@@ -12,19 +12,19 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
+using FileSplitter.Enums;
 using System;
 
 namespace FileSplitter {
 
     internal class ComboboxItem {
 
-        public ComboboxItem(String text, OPERATION_SPIT key) {
+        public ComboboxItem(String text, SplitUnit key) {
             this.Text = text;
             this.Value = Value;
         }
         public string Text { get; set; }
-        public OPERATION_SPIT Value { get; set; }
-
+        public SplitUnit Value { get; set; }
         public override string ToString() {
             return Text;
         }

--- a/CommandLine.cs
+++ b/CommandLine.cs
@@ -22,7 +22,19 @@ namespace FileSplitter {
     /// <summary>
     /// Commandline parser
     /// </summary>
-    internal class CommandLine {
+    internal class CommandLine
+    {
+        internal const int SizeParameterIndex = 0, UnitParameterIndex = 2;
+        internal const string SplitParameterCmd = "split";
+        internal const string DeleteParameterCmd = "d";
+        internal const string FormatParameterCmd = "f";
+        internal const string DestinationFolderParameterCmd = "df";
+        internal const string LogFileParameterCmd = "lf";
+        internal const string UnitBytes = "b";
+        internal const string UnitKiloBytes = "kb";
+        internal const string UnitMegaBytes = "mb";
+        internal const string UnitGigaBytes = "gb";
+        internal const string UnitLines = "l";
 
         /// <summary>
         /// Parameters collection
@@ -77,35 +89,34 @@ namespace FileSplitter {
             }
             return builder.ToString().TrimEnd();
         }
-
         public void printUsageHelp() {
             Console.WriteLine("Usage:");
-            Console.WriteLine("fsplit -split <size> <unit> <filePath> [-d] [-f <format>] [-df <folder>] [-lf <file>]");
+            Console.WriteLine($"fsplit -{SplitParameterCmd} <size> <unit> <filePath> [-{DeleteParameterCmd}] [-{FormatParameterCmd} <format>] [-{DestinationFolderParameterCmd} <folder>] [-{LogFileParameterCmd} <file>]");
             Console.WriteLine();
             Console.WriteLine("Parameter help:");
             Console.WriteLine();
-            Console.WriteLine("-split");
+            Console.WriteLine($"-{SplitParameterCmd}");
             Console.WriteLine("  size        Size of parts");
-            Console.WriteLine("                If size unit is 'l' defines number of lines");
+            Console.WriteLine($"                If size unit is '{UnitLines}' defines number of lines");
             Console.WriteLine("                in other case the size in the selected unit");
-            Console.WriteLine();
-            Console.WriteLine("  unit        unit of size 'b' 'kb 'mb' 'gb' 'l'");
-            Console.WriteLine("                b  - bytes");
-            Console.WriteLine("                kb - Kilobytes");
-            Console.WriteLine("                mb - megabytes");
-            Console.WriteLine("                gb - gigabytes");
-            Console.WriteLine("                l  - lines (based on endline detection)");
+            Console.WriteLine();//TODO: Retrieve units from the SplitUnit Attributes
+            Console.WriteLine($"  unit        unit of size '{UnitBytes}' '{UnitKiloBytes} '{UnitMegaBytes}' '{UnitGigaBytes}' '{UnitLines}'");
+            Console.WriteLine($"                {UnitBytes}  - bytes");
+            Console.WriteLine($"                {UnitKiloBytes} - Kilobytes");
+            Console.WriteLine($"                {UnitMegaBytes} - megabytes");
+            Console.WriteLine($"                {UnitGigaBytes} - gigabytes");
+            Console.WriteLine($"                {UnitLines}  - lines (based on endline detection)");
             Console.WriteLine();
             Console.WriteLine("  filePath    Path of the file to be split.");
             Console.WriteLine();
-            Console.WriteLine(" -d           Delete the original file if the process is done.");
+            Console.WriteLine($" -{DeleteParameterCmd}           Delete the original file if the process is done.");
             Console.WriteLine();
-            Console.WriteLine(" -df <folder>");
+            Console.WriteLine($" -{DestinationFolderParameterCmd} <folder>");
             Console.WriteLine("              Set destination folder for files.");
-            Console.WriteLine(" -lf <file>");
+            Console.WriteLine($" -{LogFileParameterCmd} <file>");
             Console.WriteLine("              Set a file to store generated names.");
             Console.WriteLine();
-            Console.WriteLine(" -f <format>  Use a custom format using pattern replacements");
+            Console.WriteLine($" -{FormatParameterCmd} <format>  Use a custom format using pattern replacements");
             Console.WriteLine("               {0} the current part");
             Console.WriteLine("               {1} number of parts");
             Console.WriteLine();

--- a/Enums/ExceptionsMessages.cs
+++ b/Enums/ExceptionsMessages.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace FileSplitter.Enums
+{
+    internal enum ExceptionsMessages
+    {
+        ERROR_MINIMUN_PART_SIZE,
+        ERROR_OPENING_FILE,
+        ERROR_TOTALSIZE_NOTEQUALS,
+        ERROR_NO_SPACE_TO_SPLIT,
+        ERROR_FILESYSTEM_NOTALLOW_SIZE
+    }
+}

--- a/Enums/SplitUnit.cs
+++ b/Enums/SplitUnit.cs
@@ -12,27 +12,31 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-using FileSplitter.Enums;
-using System;
+using FileSplitter.Attributes;
 
-namespace FileSplitter {
+namespace FileSplitter.Enums
+{
     /// <summary>
-    /// Arguments for Split message
+    /// The unit of how to split the files
     /// </summary>
-    internal class MessageArgs : EventArgs {
-    	/// <summary>
-    	/// Message to show
-    	/// </summary>
-        public ExceptionsMessages Message { get; set; }        
-        public Object[] Parameters { get; set; }
+    /// <created>Nick</created>
+    internal enum SplitUnit
+    {
         /// <summary>
-        /// Constructor for the message
+        /// Specify an incorrect entry to allow the reflection-based parser to return 
+        /// default(T) without additional constructors and wrappers.
         /// </summary>
-        /// <param name="message"></param>
-        /// <param name="type"></param>
-        public MessageArgs(ExceptionsMessages message, Object[] parameters) {
-            this.Message = message;
-            this.Parameters = parameters;
-        }
+        /// <created>Nick</created>
+        Incorrect = 0,
+        [UnitAttribute(CommandLine.UnitBytes, 0)]
+        Bytes,
+        [UnitAttribute(CommandLine.UnitKiloBytes, 1)]
+        KiloBytes,
+        [UnitAttribute(CommandLine.UnitMegaBytes, 2)]
+        MegaBytes,
+        [UnitAttribute(CommandLine.UnitGigaBytes, 3)]
+        GigaBytes,
+        [UnitAttribute(CommandLine.UnitLines, 0)]
+        Lines
     }
 }

--- a/Exceptions/SplitFailedException.cs
+++ b/Exceptions/SplitFailedException.cs
@@ -12,9 +12,6 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-using System;
-
-namespace FileSplitter {
-    internal class SplitFailedException : Exception{
-    }
+namespace FileSplitter.Exceptions {
+    internal class SplitFailedException : System.Exception { }
 }

--- a/FileSplitter.csproj
+++ b/FileSplitter.csproj
@@ -93,11 +93,14 @@
     </Compile>
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Splitter\FileSplitter.cs" />
+    <Compile Include="Enums\ExceptionsMessages.cs" />
+    <Compile Include="Enums\SplitUnit.cs" />
+    <Compile Include="Splitter\FileSplitWorker.cs" />
     <Compile Include="Splitter\MessageArgs.cs" />
     <Compile Include="Splitter\ProcessingArgs.cs" />
-    <Compile Include="Splitter\SplitFailedException.cs" />
+    <Compile Include="Exceptions\SplitFailedException.cs" />
     <Compile Include="Splitter\Utils.cs" />
+    <Compile Include="Attributes\UnitAttribute.cs" />
     <Content Include="Test\test_256.txt" />
     <Content Include="Test\test_28.txt" />
     <EmbeddedResource Include="FrmSplitter.resx">

--- a/FrmSplitter.cs
+++ b/FrmSplitter.cs
@@ -12,6 +12,7 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
+using FileSplitter.Enums;
 using System;
 using System.Windows.Forms;
 
@@ -25,7 +26,7 @@ namespace FileSplitter {
         /// <summary>
         /// Spliter class. Do Split operations
         /// </summary>
-        private FileSplitter fileSplitter;
+        private FileSplitWorker fileSplitter;
 
         /// <summary>
         /// Start Components & assign events
@@ -44,17 +45,17 @@ namespace FileSplitter {
             this.lbEstimatedParts.Text = Properties.Resources.SPLINT_INFO_PARTS_DEF;
             this.Text = Properties.Resources.TITLE;
 
-            cmbUnits.Items.Add(new ComboboxItem("bytes", OPERATION_SPIT.BY_BYTE));
-            cmbUnits.Items.Add(new ComboboxItem("Kilobytes", OPERATION_SPIT.BY_KBYTE));
-            cmbUnits.Items.Add(new ComboboxItem("Megabytes", OPERATION_SPIT.BY_MBYTE));
-            cmbUnits.Items.Add(new ComboboxItem("Gigabytes", OPERATION_SPIT.BY_GBYTE));
-            cmbUnits.Items.Add(new ComboboxItem(Properties.Resources.CMB_LINES, OPERATION_SPIT.BY_LINES));
+            cmbUnits.Items.Add(new ComboboxItem("bytes", SplitUnit.Bytes));
+            cmbUnits.Items.Add(new ComboboxItem("Kilobytes", SplitUnit.KiloBytes));
+            cmbUnits.Items.Add(new ComboboxItem("Megabytes", SplitUnit.MegaBytes));
+            cmbUnits.Items.Add(new ComboboxItem("Gigabytes", SplitUnit.GigaBytes));
+            cmbUnits.Items.Add(new ComboboxItem(Properties.Resources.CMB_LINES, SplitUnit.Lines));
 
-            fileSplitter = new FileSplitter();
-            fileSplitter.start += new FileSplitter.StartHandler(fileSplitter_splitStart);
-            fileSplitter.finish += new FileSplitter.FinishHandler(fileSplitter_splitEnd);
-            fileSplitter.processing += new FileSplitter.ProcessHandler(fileSplitter_splitProcess);
-            fileSplitter.message += new FileSplitter.MessageHandler(fileSplitter_message);
+            fileSplitter = new FileSplitWorker();
+            fileSplitter.start += new FileSplitWorker.StartHandler(fileSplitter_splitStart);
+            fileSplitter.finish += new FileSplitWorker.FinishHandler(fileSplitter_splitEnd);
+            fileSplitter.processing += new FileSplitWorker.ProcessHandler(fileSplitter_splitProcess);
+            fileSplitter.message += new FileSplitWorker.MessageHandler(fileSplitter_message);
 
             cmbUnits.SelectedIndex = 2;
 
@@ -73,7 +74,7 @@ namespace FileSplitter {
         /// <param name="args">Paramaters of actual split</param>
         void fileSplitter_splitProcess(object sender, ProcessingArgs args) {
             lbSplitInfo.Text = String.Format(Properties.Resources.SPLITTING_FILE, args.FileName);
-            if (fileSplitter.OperationMode !=  OPERATION_SPIT.BY_LINES) {
+            if (fileSplitter.OperationMode != SplitUnit.Lines) {
                 progressBarFiles.Style = ProgressBarStyle.Continuous;
                 int percPart = Convert.ToInt32((args.Part * 100) / args.Parts);
                 if (percPart < progressBarFiles.Maximum) {
@@ -123,7 +124,7 @@ namespace FileSplitter {
             if (openFileDialog.ShowDialog() == DialogResult.OK) {
                 cmdStart.Enabled = true;
                 fileSplitter.FileName =  this.txtFile.Text = openFileDialog.FileName;
-                if (fileSplitter.OperationMode !=  OPERATION_SPIT.BY_LINES) {
+                if (fileSplitter.OperationMode != SplitUnit.Lines) {
                     lbEstimatedParts.Text = String.Format(Properties.Resources.SPLIT_INFO_PARTS, fileSplitter.Parts);
                 } else {
                     lbEstimatedParts.Text = Properties.Resources.NUMBER_OF_LINES;
@@ -143,7 +144,7 @@ namespace FileSplitter {
                 fileSplitter.OperationMode = ((ComboboxItem)cmbUnits.SelectedItem).Value;
             }
             fileSplitter.PartSize = Utils.unitConverter((Int64)numSize.Value, fileSplitter.OperationMode);
-            if (fileSplitter.OperationMode != OPERATION_SPIT.BY_LINES ){
+            if (fileSplitter.OperationMode != SplitUnit.Lines ){
                 lbEstimatedParts.Text = String.Format(Properties.Resources.SPLIT_INFO_PARTS, fileSplitter.Parts);
             } else {
                 lbEstimatedParts.Text = Properties.Resources.NUMBER_OF_LINES;

--- a/Splitter/FileSplitter.cs
+++ b/Splitter/FileSplitter.cs
@@ -376,7 +376,8 @@ namespace FileSplitter {
 
                 // Builds default pattern if FileFormatPattern is null
                 if (FileFormatPattern == null) {
-                    String zeros = new String('0',  this.Parts); // Padding
+                    // Use the part's string length (e.g. '123' -> 3) to determine the amount of padding needed
+                    String zeros = new String('0', this.Parts.ToString().Length); // Padding
                     FileFormatPattern = Path.GetFileNameWithoutExtension(this.FileName) + "_{0:" + zeros + "}({1:" + zeros + "})" + fileNameInfo.Extension;
                 }
                 

--- a/Splitter/ProcessingArgs.cs
+++ b/Splitter/ProcessingArgs.cs
@@ -13,73 +13,28 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 using System;
-
 namespace FileSplitter {
-
     internal class ProcessingArgs : EventArgs {
-
         /// <summary>
         /// File Name
         /// </summary>
-        private String fileName = String.Empty;
-
+        public String FileName { get; private set; } = String.Empty;
         /// <summary>
         /// Part number of total parts
         /// </summary>
-        private Int64 part = 0;
-
+        public Int64 Part { get; private set; } = 0;
         /// <summary>
         /// Partsize Written
         /// </summary>
-        private Int64 partSizeWritten = 0;
-
+        public Int64 PartSizeWritten { get; private set; } = 0;
         /// <summary>
         /// Total parts
         /// </summary>
-        private Int64 parts;
-
+        public Int64 Parts { get; private set; }
         /// <summary>
         /// Size in bytes of each part
         /// </summary>
-        private Int64 partSize;
-
-        /// <summary>
-        /// Geter for FileName
-        /// </summary>
-        public String FileName {
-            get { return fileName; }
-        }
-
-        /// <summary>
-        /// Getter for Actual Part
-        /// </summary>
-        public Int64 Part {
-            get { return part; }
-        }
-
-        /// <summary>
-        /// Getter for bytes written of actual Part
-        /// </summary>
-        public Int64 PartSizeWritten {
-            get { return partSizeWritten; }
-        }
-
-        /// <summary>
-        /// Getter for  Size of a part in bytes
-        /// </summary>
-        public Int64 PartSize {
-            get { return partSize; }
-            set { partSize = value; }
-        }
-
-        /// <summary>
-        /// Getter for  Total parts expected
-        /// </summary>
-        public Int64 Parts {
-            get { return parts; }
-            set { parts = value; }
-        }
-
+        public Int64 PartSize { get; private set; }
         /// <summary>
         /// Argument constructor
         /// </summary>
@@ -89,11 +44,11 @@ namespace FileSplitter {
         /// <param name="totalParts">Total parts</param>
         /// <param name="partSize">Total size expected of each part</param>
         public ProcessingArgs(String file, Int64 part, Int64 partSizeWritten, Int64 totalParts, Int64 partSize) {
-            this.fileName = file;
-            this.part = part;
-            this.partSizeWritten = partSizeWritten;
-            this.parts = totalParts;
-            this.partSize = partSize;
+            FileName = file;
+            Part = part;
+            PartSizeWritten = partSizeWritten;
+            Parts = totalParts;
+            PartSize = partSize;
         }
     }
 }

--- a/Splitter/Utils.cs
+++ b/Splitter/Utils.cs
@@ -80,7 +80,7 @@ namespace FileSplitter
                     message = String.Format(Properties.Resources.ERROR_OPENING_FILE, args);
                     break;
                 case ExceptionsMessages.ERROR_TOTALSIZE_NOTEQUALS:
-                    message = Properties.Resources.ERROR_OPENING_FILE;
+                    message = Properties.Resources.ERROR_TOTALSIZE_NOTEQUALS;
                     break;
                 default:
                     message = string.Empty;

--- a/Splitter/Utils.cs
+++ b/Splitter/Utils.cs
@@ -12,26 +12,16 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
+using FileSplitter.Attributes;
+using FileSplitter.Enums;
 using System;
 using System.IO;
 using System.Text;
 using System.Windows.Forms;
 
-namespace FileSplitter {
-
-    internal enum OPERATION_SPIT {
-        BY_BYTE,
-        BY_KBYTE,
-        BY_MBYTE,
-        BY_GBYTE,
-        BY_LINES
-
-    }
-
-
+namespace FileSplitter
+{
     internal abstract class Utils {
-
-
         /// <summary>
         /// Detects the byte order mark of a file and returns
         /// an appropriate encoding for the file.
@@ -60,66 +50,58 @@ namespace FileSplitter {
             }
             return enc;
         }
-
         /// <summary>
         ///  Unit order converter
         /// </summary>
         /// <param name="items"></param>
-        /// <param name="unitOrder">0 bytes 1 kbytes 2 Mbytes 3 Gb 4 Lines</param>
+        /// <param name="units">Kind of split unit to use</param>
         /// <returns></returns>
-        public static Int64 unitConverter(Int64 items, OPERATION_SPIT units) {
+        public static Int64 unitConverter(Int64 items, SplitUnit units) {
             Int64 result = items;
-            Int64 factor = 0;
-            switch (units) {
-                case OPERATION_SPIT.BY_KBYTE:
-                    factor = 1;
-                    break;
-                case OPERATION_SPIT.BY_MBYTE:
-                    factor = 2;
-                    break;
-                case OPERATION_SPIT.BY_GBYTE:
-                    factor = 3;
-                    break;
-            }
-            if (factor > 0) {
-                result = (Int64)Math.Ceiling(items * Math.Pow(1024, factor));
+            var info = UnitAttribute.GetFromField<SplitUnit>(units);
+            if (info.Factor > 0) {
+                result = (Int64)Math.Ceiling(items * info.CalculatedFactor);
             }
             return result;
         }
-
-        public static String getMessageText(MESSAGE msg,params Object[] args) {
-            String message = "";
+        public static String getMessageText(ExceptionsMessages msg,params Object[] args) {
+            String message;
             switch (msg) {
-                case MESSAGE.ERROR_FILESYSTEM_NOTALLOW_SIZE:
+                case ExceptionsMessages.ERROR_FILESYSTEM_NOTALLOW_SIZE:
                     message = String.Format(Properties.Resources.ERROR_FILESYSTEM_NOTALLOW_SIZE, args);
                     break;
-                case MESSAGE.ERROR_MINIMUN_PART_SIZE:
-                    message = String.Format(Properties.Resources.ERROR_MINIMUN_PART_SIZE, args);
+                case ExceptionsMessages.ERROR_MINIMUN_PART_SIZE:
+                    message = string.Format(Properties.Resources.ERROR_MINIMUN_PART_SIZE, args);
                     break;
-                case MESSAGE.ERROR_NO_SPACE_TO_SPLIT:
+                case ExceptionsMessages.ERROR_NO_SPACE_TO_SPLIT:
                     message = Properties.Resources.ERROR_NO_SPACE_TO_SPLIT;
                     break;
-                case MESSAGE.ERROR_OPENING_FILE:
+                case ExceptionsMessages.ERROR_OPENING_FILE:
                     message = String.Format(Properties.Resources.ERROR_OPENING_FILE, args);
                     break;
-                case MESSAGE.ERROR_TOTALSIZE_NOTEQUALS:
+                case ExceptionsMessages.ERROR_TOTALSIZE_NOTEQUALS:
                     message = Properties.Resources.ERROR_OPENING_FILE;
+                    break;
+                default:
+                    message = string.Empty;
                     break;
             }
             return message;
         }
-
-        public static MessageBoxIcon getMessageIcon(MESSAGE msg) {
-            MessageBoxIcon icon = MessageBoxIcon.Information;
+        public static MessageBoxIcon getMessageIcon(ExceptionsMessages msg) {
+            MessageBoxIcon icon;
             switch (msg) {
-                case MESSAGE.ERROR_NO_SPACE_TO_SPLIT:
-                case MESSAGE.ERROR_OPENING_FILE:
+                case ExceptionsMessages.ERROR_NO_SPACE_TO_SPLIT:
+                case ExceptionsMessages.ERROR_OPENING_FILE:
                     icon = MessageBoxIcon.Hand;
                     break;
-                case MESSAGE.ERROR_FILESYSTEM_NOTALLOW_SIZE:
-                case MESSAGE.ERROR_MINIMUN_PART_SIZE:
-                case MESSAGE.ERROR_TOTALSIZE_NOTEQUALS:
+                case ExceptionsMessages.ERROR_FILESYSTEM_NOTALLOW_SIZE:
+                case ExceptionsMessages.ERROR_MINIMUN_PART_SIZE:
+                case ExceptionsMessages.ERROR_TOTALSIZE_NOTEQUALS:
                     icon = MessageBoxIcon.Error;
+                    break;
+                default:
+                    icon = MessageBoxIcon.Information;
                     break;
             }
             return icon;


### PR DESCRIPTION
Moved objects into separate files
Renamed Splitter\FileSplitter to FIleSplitWorker to remove naming conflict with namespace and prevent usage of global::
Rewritten ProcessingArgs to make use of auto properties; e.g. public Type X (get; private set;} = default;
Fixed bug in 'ERROR_TOTALSIZE_NOTEQUALS' (pointed to wrong resource)
Fixed code to match the original comments (Minimum part size was described as 4kb but code had 1kb); it's now in a static readonly variable so you can update it as needed.
Refactured parameter parsing to re-use an inline Func