### PR TITLE
Fix for Utils code that determines the amount of parts

### DIFF
--- a/Splitter/Utils.cs
+++ b/Splitter/Utils.cs
@@ -58,9 +58,15 @@ namespace FileSplitter
         /// <returns></returns>
         public static Int64 unitConverter(Int64 items, SplitUnit units) {
             Int64 result = items;
-            var info = UnitAttribute.GetFromField<SplitUnit>(units);
-            if (info.Factor > 0) {
-                result = (Int64)Math.Ceiling(items * info.CalculatedFactor);
+            // Make sure to check if it's something valid we can split
+            if (units != SplitUnit.Incorrect)
+            {
+                var info = UnitAttribute.GetFromField<SplitUnit>(units);
+                // If the GetFromField fails; make sure to test it's not null
+                if (info != null && info.Factor > 0)
+                {
+                    result = (Int64)Math.Ceiling(items * info.CalculatedFactor);
+                }
             }
             return result;
         }


### PR DESCRIPTION
Fix for Utils code that determines the amount of parts; used to crash
the application if run without parameters.